### PR TITLE
Change color-scheme for metro and tram

### DIFF
--- a/views/metro.html
+++ b/views/metro.html
@@ -3,6 +3,8 @@
   <head>
     <title> Metasl2.0 </title>
     <script src='/socket.io/socket.io.js'></script>
+    <script src='/public/js/clock.js'></script>
+    <link rel="stylesheet" type="text/css" media="screen" href="/public/css/clock.css" />
     <script>
       var getTopText = function(group, callback) {
         var text = '<span class="dest">' + group[0].LineNumber + ' ' +  group[0].Destination + '</span><span class="time">' + group[0].DisplayTime + '</span>';

--- a/views/metro.html
+++ b/views/metro.html
@@ -3,8 +3,6 @@
   <head>
     <title> Metasl2.0 </title>
     <script src='/socket.io/socket.io.js'></script>
-    <script src='/public/js/clock.js'></script>
-    <link rel="stylesheet" type="text/css" media="screen" href="/public/css/clock.css" />
     <script>
       var getTopText = function(group, callback) {
         var text = '<span class="dest">' + group[0].LineNumber + ' ' +  group[0].Destination + '</span><span class="time">' + group[0].DisplayTime + '</span>';
@@ -76,7 +74,7 @@
         background-color: black;
         border: solid;
         border-width: 20px;
-        border-color: gray;
+        border-color: #222;
         height: 260px;
       }
       div#groupone {
@@ -172,6 +170,5 @@
       </div>
       <p> Data provided by <a href="http://trafiklab.se">trafiklab</a></p>
     </div>
-    <div id='clock'></div>
   </body>
 </html>

--- a/views/tram.html
+++ b/views/tram.html
@@ -37,20 +37,20 @@
       h3 {
         font-size: 90px;
         text-align: center;
-        background-color: black;
-        color: yellow;
-        border-bottom: solid 10px red;
+        background-color: #242424;
+        color: #FFE432; /*#F9FAF4;
+        border-bottom: solid 10px #cb4b16;*/
       }
 
       div#tram>div {
         height: 70px;
-        background-color: black;
+        background-color: #0c0c0c;
         padding: 0px 20px;
       }
 
       div#tram>div>p>span {
         font-size: 60px;
-        color: yellow
+        color: #FFE432;
       }
 
       span.linenr {


### PR DESCRIPTION
Tänker 'less is more' och tar bort den röda linjen.  
Osäker på huruvida skillnad i gråskala syns på TV-apparaterna.